### PR TITLE
Static compilation of Go binary for cross-environment compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ FROM chromedp/headless-shell:109.0.5396.2 as final
 WORKDIR /app
 COPY --from=build /src/main ./
 
+ENTRYPOINT []
 CMD ["./main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . ./
 
 RUN go mod download
 
-RUN go build -o main .
+RUN CGO_ENABLED=0 go build -o main .
 
 FROM chromedp/headless-shell:109.0.5396.2 as final
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
     volumes:
       - ./cptch:/app/cptch
       - ./screenshots:/app/screenshots
+      - ./.env:/app/.env


### PR DESCRIPTION
Modified the Docker build process to statically compile the Go application. By setting `CGO_ENABLED=0`, we ensure the binary does not rely on the underlying C library (like musl or glibc), making it portable across different base images. This resolves issues encountered when moving the binary from an Alpine-based Go image to a different base image.